### PR TITLE
entrypoint: launch with --no-sandbox

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,4 +5,4 @@ set -o errexit
 TMPDIR="${XDG_CACHE_HOME}"/tmp/
 export TMPDIR
 
-exec env /app/Wire/wire-desktop "$@"
+exec env /app/Wire/wire-desktop --no-sandbox "$@"


### PR DESCRIPTION
Since electron 6, chromium refuses to launch unless its sandboxing  is explicitly disabled

fixes:

```
[180:0108/153050.861601:FATAL:setuid_sandbox_host.cc(157)] The SUID sandbox helper binary was found, but is not configured correctly. Rather than run without sandboxing I'm aborting now. You need to make sure that /app/Wire/chrome-sandbox is owned by root and has mode 4755.
```