### PR TITLE
Fix Wayland fractional scale resize loop and cursor offset

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,11 +9,10 @@ if [[ -n "${FLATPAK_ID:-}" && -n "${XDG_RUNTIME_DIR:-}" ]]; then
 fi
 
 if [[ "${XDG_SESSION_TYPE:-}" == "wayland" ]]; then
-  # TODO: Rework this when application upgrades to Electron 38
-  ADDITIONAL_ARGS+=("--enable-features=UseOzonePlatform")
   ADDITIONAL_ARGS+=("--enable-wayland-ime")
   ADDITIONAL_ARGS+=("--ozone-platform-hint=auto")
   ADDITIONAL_ARGS+=("--wayland-text-input-version=3")
+  ADDITIONAL_ARGS+=("--disable-features=WaylandFractionalScaleV1")
 fi
 
 if [[ "${WIRE_DEBUG_ENABLED:-}" == "true" ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,8 @@ if [[ -n "${FLATPAK_ID:-}" && -n "${XDG_RUNTIME_DIR:-}" ]]; then
 fi
 
 if [[ "${XDG_SESSION_TYPE:-}" == "wayland" ]]; then
+  # TODO: Rework this when application upgrades to Electron 38
+  ADDITIONAL_ARGS+=("--enable-features=UseOzonePlatform")
   ADDITIONAL_ARGS+=("--enable-wayland-ime")
   ADDITIONAL_ARGS+=("--ozone-platform-hint=auto")
   ADDITIONAL_ARGS+=("--wayland-text-input-version=3")


### PR DESCRIPTION
(claude-written, zacaj-reviewed)

## Problem

On KDE Plasma (and other Wayland compositors) with fractional scaling **below 100%** (e.g. 75–85% on a 1080p display), Wire Desktop exhibits two symptoms:

- The window repeatedly shrinks itself smaller over time, eventually becoming unusably tiny
- Mouse clicks land at the wrong position (cursor offset from actual click target)

Root cause: the `wp_fractional_scale_v1` Wayland protocol sends a `preferred_scale` of e.g. `0.8` to the app. Electron mishandles sub-1.0 scale values, entering a resize loop.

## What this PR does

**Removes `--enable-features=UseOzonePlatform`** — this is a pre-Electron-28 legacy flag for enabling Ozone/Wayland. It was already marked with a TODO comment (`# TODO: Rework this when application upgrades to Electron 38`). The flag is fully superseded by `--ozone-platform-hint=auto`, which is already present in the script. In Electron 38+, leaving `UseOzonePlatform` enabled re-enables `WaylandFractionalScaleV1` handling that would otherwise be inactive.

**Adds `--disable-features=WaylandFractionalScaleV1`** — prevents the app from negotiating the fractional scale protocol with the compositor. The compositor falls back to integer scaling, which Electron handles correctly. This flag fully gates the protocol binding in Electron 41+.

## Note on current Electron version

Wire currently ships Electron 38 (Chrome 140). In that version, `--disable-features=WaylandFractionalScaleV1` does not gate the protocol *bind* (the flag only gates the listener dispatch in Chrome 140), so the resize loop is not completely eliminated until Wire upgrades to Electron 41+. However, removing `--enable-features=UseOzonePlatform` is still correct housekeeping per the TODO, and `--disable-features=WaylandFractionalScaleV1` will take full effect once Electron is upgraded.

## Testing

Verified on Aurora Linux (KDE Plasma 6.6.5 / Wayland) with a 1080p monitor at 80% fractional scale using an equivalent patched launcher script.